### PR TITLE
feat: flag -A in Longshot is now optional

### DIFF
--- a/artic/minion.py
+++ b/artic/minion.py
@@ -242,7 +242,10 @@ def run(parser, args):
     if args.medaka and not args.no_longshot:
         cmds.append("bgzip -f %s.merged.vcf" % (args.sample))
         cmds.append("tabix -f -p vcf %s.merged.vcf.gz" % (args.sample))
-        cmds.append("longshot -P 0 -F -A --no_haps --bam %s.primertrimmed.rg.sorted.bam --ref %s --out %s.merged.vcf --potential_variants %s.merged.vcf.gz" % (args.sample, ref, args.sample, args.sample))
+        if args.no_auto_max_cov:
+            cmds.append("longshot -P 0 -F --no_haps --bam %s.primertrimmed.rg.sorted.bam --ref %s --out %s.merged.vcf --potential_variants %s.merged.vcf.gz" % (args.sample, ref, args.sample, args.sample))
+        else:
+            cmds.append("longshot -P 0 -F -A --no_haps --bam %s.primertrimmed.rg.sorted.bam --ref %s --out %s.merged.vcf --potential_variants %s.merged.vcf.gz" % (args.sample, ref, args.sample, args.sample))
 
     ## set up some name holder vars for ease
     if args.medaka:

--- a/artic/pipeline.py
+++ b/artic/pipeline.py
@@ -99,6 +99,7 @@ def init_pipeline_parser():
                                help='Use medaka instead of nanopolish for variants')
     parser_minion.add_argument('--medaka-model', metavar='medaka_model', help='The model to use for medaka (required if using --medaka)')
     parser_minion.add_argument('--no-longshot', dest='no_longshot', action='store_true', help='Do not use Longshot for variant filtering after medaka')
+    parser_minion.add_argument('--no-auto_max_cov', dest='no_auto_max_cov', action='store_true', help='When running Longshot, do not use its --auto_max_cov flag')
     parser_minion.add_argument('--minimap2', dest='minimap2', default=True,
                                action='store_true', help='Use minimap2 (default)')
     parser_minion.add_argument(


### PR DESCRIPTION
Card: https://trello.com/c/Dxn6SLZu

## ℹ Descrição
<!--
Apresente sucintamente o problema existente que o PR corrige ou a feature que o PR implementa. Caso tenha imagens ou gifs, é um bom local para colocar.
-->
O problema foi primeiro identificado no barcode13 da Run020, e é conhecido (ver issues https://github.com/pjedge/longshot/issues/72 e https://github.com/artic-network/fieldbioinformatics/issues/91). O Artic chama o `longshot`  com a flag `-A` , que tenta estimar automaticamente a cobertura máxima, mas dá erro se o arquivo estiver vazio ou com poucas reads, pois o número é arredondado pra zero. Simplesmente não usar essa flag é uma solução que pode ser adotada e provavelmente não terá efeitos colaterais prejudiciais.

## 👩‍💻 Detalhes técnicos
<!--
Nesta seção você pode justificar escolhas técnicas e detalhes mais específicos de código, integração com sistemas e banco.
Reporte oportunidades de melhoria ou questionamentos sobre o processo, visando longo prazo.
-->
Foi adicionada uma nova opção `--no-auto_max_cov` no comando `artic minion`. Quando o programa é executado com essa flag, a chamada do Longshot é feita sem a flag `-A` (alternativa a `--auto_max_cov`).
Uma explicação sobre a nova flag foi adicionada no help (`artic minion -h`)

## Fluxos e sistemas afetados
<!--
Relacione os fluxos e sistemas que você tem conhecimento que são afetados pelas mudanças feitas neste PR.
Exemplo: uma alteração no client do Cromwell pode afetar a criação de workflows de Covid
-->
Neste momento nenhum, mas o objetivo é usar este repo como base para a imagem Docker, no lugar do original (https://github.com/artic-network/fieldbioinformatics). Quando isto for feito, serão afetadas as pipelines `MultiViralPipeline_Artic` e `SarsCov2LineagePipeline`.

### 📃 Testes
<!--
Apresente os fluxos de teste/QA que você planejou. Para cada caso diga o comportamento esperado.
-->
Foi feito um teste usando o arquivo `QVirus_Run024.barcode20.Influenza-A_H3N2_S7.fastq` (ver card), e os comandos:
```
artic minion --medaka --medaka-model r10_min_high_g340 --normalise 200 --threads 8 --no-auto_max_cov --strict --read-file QVirus_Run024.barcode20.Influenza-A_H3N2_S7.fastq --scheme-directory /home/renan/Artic/QVirus_V2/Influenza-A/H3N2 S7/V1 QVirus_Run024.barcode20.Influenza-A_H3N2_S7
```
```
artic minion --medaka --medaka-model r10_min_high_g340 --normalise 200 --threads 8 --strict --read-file QVirus_Run024.barcode20.Influenza-A_H3N2_S7.fastq --scheme-directory /home/renan/Artic/QVirus_V2/Influenza-A/H3N2 S7/V1 QVirus_Run024.barcode20.Influenza-A_H3N2_S7
```
O primeiro tem sucesso e o segundo falha.

**Nota:** É necessário obter a pasta `QVirus_V2` com os primers, disponível em:
```
gs://bioinfo-dev-temp/multiviral/artic-protocols/QVirus/V2/QVirus_V2.tar.gz
```


## ➕ Dependências
<!--
Marque todos os PRs - deste e de outros repositórios - que necessitam ser mergeados antes (ou junto) deste.
Este também é o local para notifcar alguma outra dependência externa a código.
-->
Seria bom, mas não é obrigatório que este PR entre junto com o https://github.com/mendelics/fieldbioinformatics/pull/2, que corrige outro erro que estava fazendo a pipeline multiviral falhar. Quando os dois entrarem, e a imagem Docker for atualizada, deve ser possível rodar a Run020 e a Run024 sem falhas.

## Necessário para
<!--
Marque todos os PRs - deste e de outros repositórios - que necessitam que este PR seja mergeado para que funcione.
-->
Nenhum.

## ☑ Lista de revisão

**Quem cria o PR:** ao abrir, certifique-se de que todos os itens abaixo foram atendidos. Caso algum item não se aplique, justifique a não aplicabilidade na descrição do PR.

**Quem revisa o PR:** aprove apenas se todos os itens da lista estão atendidos/justificados.


### Geral
- [ ] Título segue [Conventional Commits](https://www.conventionalcommits.org/en/).
- [ ] Corpo descreve com clareza o problema atacado, descrevendo a solução concebida e possíveis limitações da abordagem.
- [ ] O PR não altera outras funcionalidades fora do escopo proposto.

### Back-End
- [ ] ~Endpoints seguem o padrão de [RESTful APIs](https://docs.mendelics.com.br/guidelines/rest/).~
- [ ] ~Endpoints estão documentados corretamente.~
- [ ] ~As mensagens de erros são descritivas e não vazam informações sensíveis ([guideline de erros](https://docs.mendelics.com.br/guidelines/errors/)).~
- [ ] ~Testes escritos no [padrão definido da aplicação](https://docs.mendelics.com.br/guidelines/testing/).~
- [ ] Não existem cenários de testes não cobertos (avaliar a cobertura).
- [ ] ~Em caso de testes muito similares foi utilizado o `mark.parametrize`.~

### Back-End - Migrations
- [ ] ~Os comandos gerados automaticamente pela(s) migration(s) não dropam/criam colunas desnecessariamente (comum na manipulação de enums).~
- [ ] ~As alterações manuais feitas na(s) migration(s) são consistentes com o banco. Isto é, ao executar o comando de gerar uma nova migration, o arquivo gerado é "vazio".~
- [ ] ~O(s) downgrade(s) da(s) migration(s) funciona(m) sem erros, mesmo com o banco populado.~

### Front-End
- [ ] ~Ao testar as alterações feitas por este PR, não são gerados erros no console do navegador.~
- [ ] ~As strings dos templates html estão dentro de arquivos de internacionalização.~
- [ ] ~O front está de acordo com as guidelines do [Material Design](https://material.io/).~