### PR TITLE
fix: Ignore bases outside the reference

### DIFF
--- a/artic/make_depth_mask.py
+++ b/artic/make_depth_mask.py
@@ -65,7 +65,7 @@ def collect_depths(bamfile, refName, minDepth, ignoreDeletions, warnRGcov):
     lowRGvec = []
 
     # generate the pileup
-    for pileupcolumn in bamFile.pileup(refName, max_depth=10000, truncate=False, min_base_quality=0):
+    for pileupcolumn in bamFile.pileup(refName, start=0, stop=bamFile.get_reference_length(refName), max_depth=10000, truncate=True, min_base_quality=0):
 
         # process the pileup column
         for pileupread in pileupcolumn.pileups:


### PR DESCRIPTION
Card: https://trello.com/c/Dxn6SLZu

## ℹ Descrição
<!--
Apresente sucintamente o problema existente que o PR corrige ou a feature que o PR implementa. Caso tenha imagens ou gifs, é um bom local para colocar.
-->
O problema foi primeiro identificado no barcode15 da Run020, que falha no `make_depth_mask`. Ocorre um erro de `Index out of range`, cuja raiz é o fato de o alinhamento ser maior que a referência: é criado um vetor do tamanho da referência, que é acessado uma posição por vez, base por base. Quando uma read sai além da referência, há falha por estouro desse vetor.

## 👩‍💻 Detalhes técnicos
<!--
Nesta seção você pode justificar escolhas técnicas e detalhes mais específicos de código, integração com sistemas e banco.
Reporte oportunidades de melhoria ou questionamentos sobre o processo, visando longo prazo.
-->
No arquivo `make_depth_mask.py` a seção que gera o pileup (lista reads que alinham com uma base específica da referência) foi alterada para ignorar bases que saem fora da referência, limiitando o pileup entre as posições 0 e tamanho da referência. Além de mais simples de implementar, esta solução não necessita de um hard clip, que resultaria em perda de informação, já que parte das reads estaria sendo eliminada.

## Fluxos e sistemas afetados
<!--
Relacione os fluxos e sistemas que você tem conhecimento que são afetados pelas mudanças feitas neste PR.
Exemplo: uma alteração no client do Cromwell pode afetar a criação de workflows de Covid
-->
Neste momento nenhum, mas o objetivo é usar este repo como base para a imagem Docker, no lugar do original (https://github.com/artic-network/fieldbioinformatics). Quando isto for feito, serão afetadas as pipelines `MultiViralPipeline_Artic` e `SarsCov2LineagePipeline`.

### 📃 Testes
<!--
Apresente os fluxos de teste/QA que você planejou. Para cada caso diga o comportamento esperado.
-->
Para o teste foi utilizado o arquivo `QVirus_Run024.barcode53.RSV_B.fastq` (ver card), com o comando:
```
artic minion --medaka --medaka-model r10_min_high_g340 --normalise 200 --threads 8 --no-auto_max_cov --strict --read-file QVirus_Run024.barcode53.RSV_B.fastq --scheme-directory /home/renan/Artic/QVirus_V2/RSV B/V1 QVirus_Run024.barcode53.RSV_B
```
Originalmente ele falhava (log em `gsutil cat gs://bioinfo-dev-temp/MultiViralPipeline_Artic/12c3c5ed-12dc-4d69-9728-67f23e54a301/call-ScatterAt21_18/shard-41/ScatterAt21_18/c31f9aca-a6bf-4cf5-94cd-99e2cd4a8ace/call-RunArticOnSample/shard-0/RunArticOnSample-0.log`), e agora finaliza a execução com sucesso.

**Nota:** É necessário obter a pasta `QVirus_V2` com os primers, disponível em:
```
gs://bioinfo-dev-temp/multiviral/artic-protocols/QVirus/V2/QVirus_V2.tar.gz
```


## ➕ Dependências
<!--
Marque todos os PRs - deste e de outros repositórios - que necessitam ser mergeados antes (ou junto) deste.
Este também é o local para notifcar alguma outra dependência externa a código.
-->
Seria bom, mas não é obrigatório que este PR entre junto com o https://github.com/mendelics/fieldbioinformatics/pull/1, que corrige outro erro que estava fazendo a pipeline multiviral falhar. Quando os dois entrarem, e a imagem Docker for atualizada, deve ser possível rodar a Run020 e a Run024 sem falhas.

## Necessário para
<!--
Marque todos os PRs - deste e de outros repositórios - que necessitam que este PR seja mergeado para que funcione.
-->
Nenhum.

## ☑ Lista de revisão

**Quem cria o PR:** ao abrir, certifique-se de que todos os itens abaixo foram atendidos. Caso algum item não se aplique, justifique a não aplicabilidade na descrição do PR.

**Quem revisa o PR:** aprove apenas se todos os itens da lista estão atendidos/justificados.


### Geral
- [ ] Título segue [Conventional Commits](https://www.conventionalcommits.org/en/).
- [ ] Corpo descreve com clareza o problema atacado, descrevendo a solução concebida e possíveis limitações da abordagem.
- [ ] O PR não altera outras funcionalidades fora do escopo proposto.

### Back-End
- [ ] ~Endpoints seguem o padrão de [RESTful APIs](https://docs.mendelics.com.br/guidelines/rest/).~
- [ ] ~Endpoints estão documentados corretamente.~
- [ ] ~As mensagens de erros são descritivas e não vazam informações sensíveis ([guideline de erros](https://docs.mendelics.com.br/guidelines/errors/)).~
- [ ] ~Testes escritos no [padrão definido da aplicação](https://docs.mendelics.com.br/guidelines/testing/).~
- [ ] Não existem cenários de testes não cobertos (avaliar a cobertura).
- [ ] ~Em caso de testes muito similares foi utilizado o `mark.parametrize`.~

### Back-End - Migrations
- [ ] ~Os comandos gerados automaticamente pela(s) migration(s) não dropam/criam colunas desnecessariamente (comum na manipulação de enums).~
- [ ] ~As alterações manuais feitas na(s) migration(s) são consistentes com o banco. Isto é, ao executar o comando de gerar uma nova migration, o arquivo gerado é "vazio".~
- [ ] ~O(s) downgrade(s) da(s) migration(s) funciona(m) sem erros, mesmo com o banco populado.~

### Front-End
- [ ] ~Ao testar as alterações feitas por este PR, não são gerados erros no console do navegador.~
- [ ] ~As strings dos templates html estão dentro de arquivos de internacionalização.~
- [ ] ~O front está de acordo com as guidelines do [Material Design](https://material.io/).~